### PR TITLE
Refactor to encapsulate mapping from resource path to url

### DIFF
--- a/src/pages/blogg.tsx
+++ b/src/pages/blogg.tsx
@@ -4,7 +4,6 @@ import { ResponsiveContainer } from '../components/ui/container/responsiveContai
 import { MarginLarge } from '../components/ui/margins/marginLarge';
 import { MarginMedium } from '../components/ui/margins/marginMedium';
 import { TextCenter } from '../components/ui/textCenter';
-import { toBlogURL } from '../utils/frontMatterToUrl';
 import { getAllBlogPosts } from '../utils/getBlogPosts';
 import { Seo } from '../components/seo/seo';
 
@@ -20,7 +19,7 @@ const blogIndex = () => {
         </TextCenter>
         <MarginLarge />
         {blogPosts.map((blogPost) => (
-          <Link key={blogPost.title} href={toBlogURL(blogPost)}>
+          <Link key={blogPost.title} href={blogPost.url}>
             <div>
               <PostListItem {...blogPost}></PostListItem>
               <MarginMedium />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,10 +12,9 @@ import { MarginSmall } from '../components/ui/margins/marginSmall';
 import { TextCenter } from '../components/ui/textCenter';
 import { projects } from '../data/projects';
 import { site } from '../data/site';
-import { PostFrontMatter } from '../types/FrontMatter';
+import { PostMetaData } from '../types/FrontMatter';
 import { PostListItem } from '../components/postListItem';
 import Link from 'next/link';
-import { toBlogURL } from '../utils/frontMatterToUrl';
 import { useRef, RefObject } from 'react';
 import { getLatestBlogPosts } from '../utils/getBlogPosts';
 
@@ -115,7 +114,7 @@ const ProjectsContent = () => {
   );
 };
 
-const ArticlesContent: React.FC<{ articles: PostFrontMatter[] }> = ({ articles }) => {
+const ArticlesContent: React.FC<{ articles: PostMetaData[] }> = ({ articles }) => {
   return (
     <>
       <TextCenter>
@@ -123,7 +122,7 @@ const ArticlesContent: React.FC<{ articles: PostFrontMatter[] }> = ({ articles }
       </TextCenter>
       <MarginMedium />
       {articles.map((post) => (
-        <Link key={post.title} href={toBlogURL(post)}>
+        <Link key={post.title} href={post.url}>
           <div>
             <PostListItem title={post.title} summary={post.summary} />
           </div>

--- a/src/types/FrontMatter.ts
+++ b/src/types/FrontMatter.ts
@@ -8,3 +8,7 @@ export interface PostFrontMatter extends FrontMatterBase {
   date: string;
   summary: string;
 }
+
+export interface PostMetaData extends PostFrontMatter {
+  url: string;
+}

--- a/src/utils/frontMatterToUrl.ts
+++ b/src/utils/frontMatterToUrl.ts
@@ -1,6 +1,4 @@
-import { PostFrontMatter } from '../types/FrontMatter';
-
-export const toBlogURL = (frontMatter: PostFrontMatter) => {
-  const blogPath = frontMatter.__resourcePath.split('/').pop();
+export const toBlogURL = (resourcePath: string) => {
+  const blogPath = resourcePath.split('/').pop();
   return `/blogg/${blogPath ? blogPath.replace('.mdx', '') : ''}`;
 };

--- a/src/utils/getBlogPosts.ts
+++ b/src/utils/getBlogPosts.ts
@@ -1,14 +1,20 @@
 import { frontMatter } from '../pages/blogg/*.mdx';
-import { PostFrontMatter } from '../types/FrontMatter';
+import { PostFrontMatter, PostMetaData } from '../types/FrontMatter';
 import { sortBlogPostsAscByDate } from './sortBlogPostsByDate';
+import { toBlogURL } from './frontMatterToUrl';
 
 const blogPosts = (frontMatter as unknown) as PostFrontMatter[];
 
-export const getAllBlogPosts = () => {
+const toPostMetaData = (frontMatter: PostFrontMatter): PostMetaData => ({
+  ...frontMatter,
+  url: toBlogURL(frontMatter.__resourcePath),
+});
+
+export const getAllBlogPosts = (): PostMetaData[] => {
   const sortedBlogPosts = blogPosts.sort(sortBlogPostsAscByDate);
-  return sortedBlogPosts;
+  return sortedBlogPosts.map(toPostMetaData);
 };
 
-export const getLatestBlogPosts = (num: number) => {
-  return blogPosts.sort(sortBlogPostsAscByDate).slice(0, num);
+export const getLatestBlogPosts = (num: number): PostMetaData[] => {
+  return blogPosts.sort(sortBlogPostsAscByDate).slice(0, num).map(toPostMetaData);
 };


### PR DESCRIPTION
## What this pull request does

This pull requests refactors converting from `frontmatter.__resourcePath` to relative blog urls by encapsulating this functionality in the utils function that is used to get blog posts. This means that other parts of the application does not have to be responsible to convert to blog post urls