### PR TITLE
Add subheader to prev/next post cards

### DIFF
--- a/src/components/cardPost.tsx
+++ b/src/components/cardPost.tsx
@@ -8,7 +8,7 @@ import { TextMuted } from './ui/content/textMuted';
 import styled from 'styled-components';
 
 const SubHeader = styled(TextMuted)`
-  font-size: 0.7rem;
+  font-size: var(--font-size-smaller);
 `;
 
 interface CardPostProps {

--- a/src/components/cardPost.tsx
+++ b/src/components/cardPost.tsx
@@ -5,18 +5,25 @@ import { Row } from './ui/container/row';
 import { MarginSmall } from './ui/margins/marginSmall';
 import { Column } from './ui/container/column';
 import { TextMuted } from './ui/content/textMuted';
+import styled from 'styled-components';
+
+const SubHeader = styled(TextMuted)`
+  font-size: 0.7rem;
+`;
 
 interface CardPostProps {
   post: PostMetaData;
+  subHeader?: string;
 }
 
-export const CardPost: React.FC<CardPostProps> = ({ post }) => (
+export const CardPost: React.FC<CardPostProps> = ({ post, subHeader }) => (
   <Card style={{ cursor: 'pointer' }}>
     <Link href={post.url}>
       <Row style={{ height: '100%' }}>
         <MarginSmall />
         <Column style={{ alignItems: 'stretch' }}>
           <MarginSmall />
+          {subHeader && <SubHeader>{subHeader}</SubHeader>}
           <h3 style={{ marginTop: '0' }}>{post.title}</h3>
           <TextMuted>{post.date}</TextMuted>
         </Column>

--- a/src/components/ui/content/textMuted.tsx
+++ b/src/components/ui/content/textMuted.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const TextMuted = styled.p`
   color: var(--text-muted-color);
-  font-size: 0.8rem;
+  font-size: var(--font-size-small);
 `;
 
 TextMuted.displayName = 'TextMuted';

--- a/src/components/ui/globalStyle.tsx
+++ b/src/components/ui/globalStyle.tsx
@@ -26,6 +26,8 @@ export const GlobalStyle = createGlobalStyle`
     --font-size-h4: ${theme.fonts.size.h4};
     --font-size-h5: ${theme.fonts.size.h5};
     --font-size-h6: ${theme.fonts.size.h6};
+    --font-size-small: ${theme.fonts.size.small};
+    --font-size-smaller: ${theme.fonts.size.smaller};
 
     /* Setup colors */
     --primary-color: ${theme.colors.primary};

--- a/src/layouts/blogPost.tsx
+++ b/src/layouts/blogPost.tsx
@@ -38,8 +38,8 @@ export default (frontMatter: PostFrontMatter) => {
                 <MarginMedium />
                 <h2>Mer innehåll</h2>
                 <ResponsiveGrid itemWidth="250px" gutter={theme.margins.large}>
-                  {prevPost && <CardPost post={prevPost} />}
-                  {nextPost && <CardPost post={nextPost} />}
+                  {prevPost && <CardPost subHeader="Föregående" post={prevPost} />}
+                  {nextPost && <CardPost subHeader="Nästa" post={nextPost} />}
                 </ResponsiveGrid>
               </>
             )}

--- a/src/theme/fonts.ts
+++ b/src/theme/fonts.ts
@@ -12,6 +12,8 @@ interface Fonts {
     h4: string;
     h5: string;
     h6: string;
+    small: string;
+    smaller: string;
   };
 }
 
@@ -29,5 +31,7 @@ export const fonts: Fonts = {
     h4: '1.2rem',
     h5: '1.1rem',
     h6: '1rem',
+    small: '0.8rem',
+    smaller: '0.7rem',
   },
 };


### PR DESCRIPTION
## What this pull request does

This pull request adds prev/next text for cards linking to other posts in blog post layout.

Also added 2 new font sizes: `--font-size-small` and `--font-size-smaller` to be used for scenarios like this.

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
