### PR TITLE
Refactor name of unstyled link component

### DIFF
--- a/src/components/cardPost.tsx
+++ b/src/components/cardPost.tsx
@@ -5,7 +5,7 @@ import { MarginSmall } from './ui/margins/marginSmall';
 import { Column } from './ui/container/column';
 import { TextMuted } from './ui/content/textMuted';
 import styled from 'styled-components';
-import { UnstyledNextLink } from './ui/content/unstyledLink';
+import { UnstyledInternalLink } from './ui/content/unstyledLink';
 
 const SubHeader = styled(TextMuted)`
   font-size: var(--font-size-smaller);
@@ -18,7 +18,7 @@ interface CardPostProps {
 
 export const CardPost: React.FC<CardPostProps> = ({ post, subHeader }) => (
   <Card style={{ cursor: 'pointer' }}>
-    <UnstyledNextLink href={post.url}>
+    <UnstyledInternalLink href={post.url}>
       <Row style={{ height: '100%' }}>
         <MarginSmall />
         <Column style={{ alignItems: 'stretch' }}>
@@ -29,7 +29,7 @@ export const CardPost: React.FC<CardPostProps> = ({ post, subHeader }) => (
         </Column>
         <MarginSmall />
       </Row>
-    </UnstyledNextLink>
+    </UnstyledInternalLink>
   </Card>
 );
 

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -3,7 +3,7 @@ import { useDarkMode } from '../../hooks/useDarkMode';
 import { Fill } from '../ui/container/fill';
 import { ResponsiveContainer } from '../ui/container/responsiveContainer';
 import { Row } from '../ui/container/row';
-import { UnstyledNextLink } from '../ui/content/unstyledLink';
+import { UnstyledInternalLink } from '../ui/content/unstyledLink';
 import { IconDarkMode } from '../ui/icons/iconDarkMode';
 import { IconLightMode } from '../ui/icons/iconLightMode';
 import { MarginMedium } from '../ui/margins/marginMedium';
@@ -16,14 +16,14 @@ export const Navbar = () => {
     <NavbarWrapper>
       <ResponsiveContainer>
         <NavbarContentWrapper>
-          <UnstyledNextLink href="/">
+          <UnstyledInternalLink href="/">
             <NavbarItem>Daniel Vernberg</NavbarItem>
-          </UnstyledNextLink>
+          </UnstyledInternalLink>
           <Fill />
           <Row style={{ alignItems: 'center', cursor: 'pointer' }}>
-            <UnstyledNextLink href="/blogg">
+            <UnstyledInternalLink href="/blogg">
               <NavbarItem>Blogg</NavbarItem>
-            </UnstyledNextLink>
+            </UnstyledInternalLink>
             <MarginMedium />
             {isDarkMode ? <IconLightMode onClick={toggleDarkMode} /> : <IconDarkMode onClick={toggleDarkMode} />}
           </Row>

--- a/src/components/ui/content/unstyledLink.tsx
+++ b/src/components/ui/content/unstyledLink.tsx
@@ -13,7 +13,7 @@ export const UnstyledLink = styled.a`
 
 UnstyledLink.displayName = 'UnstyledLink';
 
-export const UnstyledNextLink: React.FC<LinkProps> = ({ children, passHref = true, ...props }) => {
+export const UnstyledInternalLink: React.FC<LinkProps> = ({ children, passHref = true, ...props }) => {
   return (
     <Link passHref={passHref} {...props}>
       <UnstyledLink>{children}</UnstyledLink>
@@ -21,4 +21,4 @@ export const UnstyledNextLink: React.FC<LinkProps> = ({ children, passHref = tru
   );
 };
 
-UnstyledNextLink.displayName = 'UnstyledNextLink';
+UnstyledInternalLink.displayName = 'UnstyledInternalLink';

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,7 +5,7 @@ import { TextCenter } from '../components/ui/content/textCenter';
 import { ButtonPrimary } from '../components/ui/buttons/ButtonPrimary';
 import { MarginMedium } from '../components/ui/margins/marginMedium';
 import { Column } from '../components/ui/container/column';
-import { UnstyledNextLink } from '../components/ui/content/unstyledLink';
+import { UnstyledInternalLink } from '../components/ui/content/unstyledLink';
 
 const page404 = () => {
   const title = '404! Sidan kunde inte hittas';
@@ -20,9 +20,9 @@ const page404 = () => {
             <MarginMedium />
             <p>Det verkar som att sidan du försöker besöka inte finns.</p>
             <MarginLarge />
-            <UnstyledNextLink href="/">
+            <UnstyledInternalLink href="/">
               <ButtonPrimary>Tillbaka till startsidan</ButtonPrimary>
-            </UnstyledNextLink>
+            </UnstyledInternalLink>
           </TextCenter>
           <MarginLarge />
         </Column>

--- a/src/pages/blogg.tsx
+++ b/src/pages/blogg.tsx
@@ -2,7 +2,7 @@ import { PostListItem } from '../components/postListItem';
 import { Seo } from '../components/seo/seo';
 import { ResponsiveContainer } from '../components/ui/container/responsiveContainer';
 import { TextCenter } from '../components/ui/content/textCenter';
-import { UnstyledNextLink } from '../components/ui/content/unstyledLink';
+import { UnstyledInternalLink } from '../components/ui/content/unstyledLink';
 import { MarginLarge } from '../components/ui/margins/marginLarge';
 import { MarginMedium } from '../components/ui/margins/marginMedium';
 import { getAllBlogPosts } from '../utils/getBlogPosts';
@@ -19,12 +19,12 @@ const blogIndex = () => {
         </TextCenter>
         <MarginLarge />
         {blogPosts.map((blogPost) => (
-          <UnstyledNextLink key={blogPost.title} href={blogPost.url}>
+          <UnstyledInternalLink key={blogPost.title} href={blogPost.url}>
             <div>
               <PostListItem {...blogPost}></PostListItem>
               <MarginMedium />
             </div>
-          </UnstyledNextLink>
+          </UnstyledInternalLink>
         ))}
       </ResponsiveContainer>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,7 @@ import { PostListItem } from '../components/postListItem';
 import { getLatestBlogPosts } from '../utils/getBlogPosts';
 import { theme } from '../theme/theme';
 import { HeadingMuted } from '../components/ui/content/headingMuted';
-import { UnstyledNextLink } from '../components/ui/content/unstyledLink';
+import { UnstyledInternalLink } from '../components/ui/content/unstyledLink';
 import { useScrollToElement } from '../hooks/useScrollToElement';
 
 export default function Home() {
@@ -61,9 +61,9 @@ export default function Home() {
           <MarginMedium />
           <Row>
             <Fill />
-            <UnstyledNextLink href="/blogg">
+            <UnstyledInternalLink href="/blogg">
               <ButtonPrimary>Alla artiklar</ButtonPrimary>
-            </UnstyledNextLink>
+            </UnstyledInternalLink>
             <Fill />
           </Row>
         </Column>
@@ -129,9 +129,9 @@ const ArticlesContent: React.FC<{ articles: PostMetaData[] }> = ({ articles }) =
       </TextCenter>
       <MarginMedium />
       {articles.map((post) => (
-        <UnstyledNextLink key={post.title} href={post.url}>
+        <UnstyledInternalLink key={post.title} href={post.url}>
           <PostListItem title={post.title} summary={post.summary} />
-        </UnstyledNextLink>
+        </UnstyledInternalLink>
       ))}
     </section>
   );

--- a/src/theme/syntaxHighlighting.ts
+++ b/src/theme/syntaxHighlighting.ts
@@ -125,7 +125,6 @@ export const syntaxHighlighting = css`
     margin-left: -1.5em;
     padding-left: 1em;
     border-left: 6px solid #88c0d0;
-    min-width: fit-content;
     @media (min-width: ${theme.breakpoints.medium}) {
       margin-right: -1.5em;
       background: #3b414ccc;


### PR DESCRIPTION
## What this pull request does

This pull request does:
* Refactor name of unstyled link component to `<UnstyledInternalLink />`. Slighty more verbose but clearer still.
* Fix a bug on highlighted code lines on smaller devices - they had a bigger font size than the rest of the lines.

### Types of changes

- [x] 🐛 Bug fixes
- [ ] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
