### PR TITLE
Use MDXComponentProvider to parse links in posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@mdx-js/react": "^1.6.6",
     "@styled-icons/feather": "^10.5.0",
     "mdx-prism": "^0.3.1",
     "next": "latest",
@@ -19,6 +20,7 @@
     "styled-reset": "^4.1.6"
   },
   "devDependencies": {
+    "@types/mdx-js__react": "^1.5.2",
     "@types/node": "12.0.12",
     "@types/react": "16.8.23",
     "@types/react-dom": "16.8.4",

--- a/src/components/cards/cardPost.tsx
+++ b/src/components/cards/cardPost.tsx
@@ -1,11 +1,11 @@
-import { PostMetaData } from '../types/FrontMatter';
-import { Card } from './ui/container/card';
-import { Row } from './ui/container/row';
-import { MarginSmall } from './ui/margins/marginSmall';
-import { Column } from './ui/container/column';
-import { TextMuted } from './ui/content/textMuted';
+import { PostMetaData } from '../../types/FrontMatter';
+import { Card } from '../ui/container/card';
+import { Row } from '../ui/container/row';
+import { MarginSmall } from '../ui/margins/marginSmall';
+import { Column } from '../ui/container/column';
+import { TextMuted } from '../ui/content/textMuted';
 import styled from 'styled-components';
-import { UnstyledInternalLink } from './ui/content/unstyledLink';
+import { UnstyledInternalLink } from '../ui/content/unstyledLink';
 
 const SubHeader = styled(TextMuted)`
   font-size: var(--font-size-smaller);

--- a/src/components/cards/cardProject.tsx
+++ b/src/components/cards/cardProject.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Card } from './ui/container/card';
-import { Column } from './ui/container/column';
-import { Fill } from './ui/container/fill';
-import { Row } from './ui/container/row';
-import { Tag } from './ui/content/tag';
-import { MarginSmall } from './ui/margins/marginSmall';
+import { Card } from '../ui/container/card';
+import { Column } from '../ui/container/column';
+import { Fill } from '../ui/container/fill';
+import { Row } from '../ui/container/row';
+import { Tag } from '../ui/content/tag';
+import { MarginSmall } from '../ui/margins/marginSmall';
 
 const CardLink = styled.a`
   color: inherit;

--- a/src/components/mdxComponents.tsx
+++ b/src/components/mdxComponents.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import { isInternalLink } from '../utils/isInternalLink';
+
+const customLinkComponent = (props: any) => {
+  const href = props.href;
+  if (isInternalLink(href)) {
+    return (
+      <Link href={href} passHref>
+        <a {...props} />
+      </Link>
+    );
+  }
+
+  return <a {...props} />;
+};
+
+export const MDXComponents = {
+  a: customLinkComponent,
+};

--- a/src/components/toolBox.tsx
+++ b/src/components/toolBox.tsx
@@ -32,7 +32,7 @@ export const ToolBox = () => {
         TypeScript för front- och backend som ligger närmst till hands i form av React och Node.
       </p>
       <MarginSmall></MarginSmall>
-      <ResponsiveGrid gutter="10px" itemWidth="150px">
+      <ResponsiveGrid gutter="10px" itemWidth="175px">
         {toolBox.map(({ title, items }) => (
           <div key={title}>
             <h3>{title}</h3>

--- a/src/data/toolbox.ts
+++ b/src/data/toolbox.ts
@@ -6,7 +6,7 @@ interface ToolboxCategory {
 export const toolBox: ToolboxCategory[] = [
   {
     title: 'Nära till hands',
-    items: ['HTML5', 'CSS och Preprocessors', 'TypeScript', 'React och Next.js', 'Node', 'Git', 'Jest'],
+    items: ['HTML5', 'CSS och Preprocessors', 'JavaScript och TypeScript', 'React och Next.js', 'Node', 'Git', 'Jest'],
   },
   { title: 'Använder gärna', items: ['NoSQL med Firebase', 'PostgreSQL', 'Sketch och Figma', 'Vue.js'] },
 ];

--- a/src/data/toolbox.ts
+++ b/src/data/toolbox.ts
@@ -6,7 +6,7 @@ interface ToolboxCategory {
 export const toolBox: ToolboxCategory[] = [
   {
     title: 'Nära till hands',
-    items: ['HTML5', 'CSS och Preprocessors', 'JavaScript och TypeScript', 'React och Next.js', 'Node', 'Git', 'Jest'],
+    items: ['HTML5, CSS och Preprocessors', 'JavaScript och TypeScript', 'React och Next.js', 'Node', 'Git', 'Jest'],
   },
   { title: 'Använder gärna', items: ['NoSQL med Firebase', 'PostgreSQL', 'Sketch och Figma', 'Vue.js'] },
 ];

--- a/src/layouts/blogPost.tsx
+++ b/src/layouts/blogPost.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CardPost } from '../components/cardPost';
+import { CardPost } from '../components/cards/cardPost';
 import { SeoBlogPost } from '../components/seo/seoBlogPost';
 import { Column } from '../components/ui/container/column';
 import { ResponsiveContainer } from '../components/ui/container/responsiveContainer';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { MDXProvider } from '@mdx-js/react';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import { GlobalStyle } from '../theme/globalStyle';
@@ -7,6 +8,7 @@ import { Footer } from '../components/footer/footer';
 import { MarginLarge } from '../components/ui/margins/marginLarge';
 import { DefaultSeo } from 'next-seo';
 import SEO from '../../next-seo.config';
+import { MDXComponents } from '../components/mdxComponents';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -19,11 +21,13 @@ function MyApp({ Component, pageProps }: AppProps) {
         />
       </Head>
       <DefaultSeo {...SEO} />
-      <GlobalStyle />
-      <Navbar />
-      <Component {...pageProps} />
-      <MarginLarge />
-      <Footer />
+      <MDXProvider components={MDXComponents}>
+        <GlobalStyle />
+        <Navbar />
+        <Component {...pageProps} />
+        <MarginLarge />
+        <Footer />
+      </MDXProvider>
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { CardProject } from '../components/cardProject';
+import { CardProject } from '../components/cards/cardProject';
 import { ToolBox } from '../components/toolBox';
 import { ButtonPrimary } from '../components/ui/buttons/ButtonPrimary';
 import { Column } from '../components/ui/container/column';

--- a/src/theme/globalStyle.tsx
+++ b/src/theme/globalStyle.tsx
@@ -38,11 +38,6 @@ export const GlobalStyle = createGlobalStyle`
     --border-radius-small: 4px;
     --border-radius: 6px;
 
-    /* Setup breakpoints */
-    --breakpoint-small: ${theme.breakpoints.small};
-    --breakpoint-medium: ${theme.breakpoints.medium};
-    --breakpoint-large: ${theme.breakpoints.large};
-
     /* Setup margins */
     --margin-small: ${theme.margins.small};
     --margin-medium: ${theme.margins.medium};

--- a/src/utils/isInternalLink.ts
+++ b/src/utils/isInternalLink.ts
@@ -1,0 +1,1 @@
+export const isInternalLink = (href: string): boolean => href.startsWith('/') || href.startsWith('#');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1162,6 +1162,13 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/mdx-js__react@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mdx-js__react/-/mdx-js__react-1.5.2.tgz#eb87df0ac135a685cc9bb01075a9036c7b395b0d"
+  integrity sha512-M/z869+SVti16ZGqMwg46XTNsBKj5/PNcId9NpjEUVPI2V8wzXpbkkhmhZy1n16nQvMAC6HJuh+Dogn8vPLV6w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/node@12.0.12":
   version "12.0.12"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.12.tgz#cc791b402360db1eaf7176479072f91ee6c6c7ca"


### PR DESCRIPTION
## What this pull request does

This pull request fixes an issue with internal links in blog posts. Internal links in next js is best used alongside `<Link />` component from **next/link** package. This PR adds custom parsing of internal links in markdown posts to be <Link /> elements instead. This means that linking from one post to another is now a more smooth experience.

This PR also: 
* Removes css variables for breakpoints since css variables cannot be used in media queries.
* Refactor toolbox items and responsiveness somewhat
* Move card components into `src/components/cards/` folder

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
