### PR TITLE
Persist dark mode settings in local storage

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,12 +1,23 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { site } from '../data/site';
+import { storage } from '../utils/storage';
+
+const storage_key = `${site.author} - dark-mode`;
 
 export const useDarkMode = () => {
   const [isDarkMode, toggle] = useState<Boolean>(false);
 
   const toggleDarkMode = (): void => {
+    storage.set(storage_key, isDarkMode ? 'false' : 'true');
     document.body.classList.toggle('dark-mode');
     toggle(!isDarkMode);
   };
+
+  useEffect(() => {
+    if (storage.get(storage_key) === 'true') {
+      toggleDarkMode();
+    }
+  }, []);
 
   return [isDarkMode, toggleDarkMode] as const;
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,4 @@
+export const storage = {
+  set: (key: string, value: string) => window.localStorage.setItem(key, value),
+  get: (key: string) => window.localStorage.getItem(key),
+};


### PR DESCRIPTION
## What this pull request does

This pull request persist dark mode state in local storage. When user clicks dark mode toggle the action is saved in local storage. This solves the following issues regarding dark mode:
* Dark mode setting is kept when user returns to site from external link links
* Dark mode setting is kept when user opens multiple tabs (multiple blog posts etc)
* Dark mode setting is kept when user closes the tab and later returns

**Note** that "flash of light mode" exists upon initial page load. Further tweaks to prevent this may be done in the future - the three points above still justified shipping the new dark mode features as is.  

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
