### PR TITLE
Refactor base icon usage

### DIFF
--- a/src/components/ui/icons/iconBase.ts
+++ b/src/components/ui/icons/iconBase.ts
@@ -18,6 +18,6 @@ export const BaseStyle = ({ hoverEffect = false }: IconProps) => css`
   ${hoverEffect ? HoverStyle : ''}
 `;
 
-export const IconBase = styled.svg<IconProps>`
+export const IconBase = (icon: any) => styled(icon)<IconProps>`
   ${BaseStyle}
 `;

--- a/src/components/ui/icons/iconBase.ts
+++ b/src/components/ui/icons/iconBase.ts
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 
 export interface IconProps {
   hoverEffect?: boolean;
+  onClick?: () => void;
 }
 
 const HoverStyle = css`

--- a/src/components/ui/icons/iconBase.ts
+++ b/src/components/ui/icons/iconBase.ts
@@ -1,8 +1,8 @@
 import styled, { css } from 'styled-components';
+import { StyledIconProps, StyledIcon } from '@styled-icons/styled-icon';
 
-export interface IconProps {
+export interface IconProps extends StyledIconProps {
   hoverEffect?: boolean;
-  onClick?: () => void;
 }
 
 const HoverStyle = css`
@@ -19,6 +19,6 @@ export const BaseStyle = ({ hoverEffect = false }: IconProps) => css`
   ${hoverEffect ? HoverStyle : ''}
 `;
 
-export const IconBase = (icon: any) => styled(icon)<IconProps>`
+export const IconBase = (icon: StyledIcon): StyledIcon => styled(icon)<IconProps>`
   ${BaseStyle}
 `;

--- a/src/components/ui/icons/iconBase.ts
+++ b/src/components/ui/icons/iconBase.ts
@@ -12,10 +12,14 @@ const HoverStyle = css`
   }
 `;
 
-export const BaseStyle = ({ hoverEffect = false }: IconProps) => css`
-  width: 24px;
+const defaultSize = css`
   height: 24px;
+  width: 24px;
+`;
+
+export const BaseStyle = ({ hoverEffect = false, size }: IconProps) => css`
   color: var(--text-muted-color);
+  ${size ? size : defaultSize};
   ${hoverEffect ? HoverStyle : ''}
 `;
 

--- a/src/components/ui/icons/iconDarkMode.tsx
+++ b/src/components/ui/icons/iconDarkMode.tsx
@@ -1,9 +1,9 @@
 import { Sunset } from '@styled-icons/feather';
-import styled from 'styled-components';
-import { BaseStyle, IconProps } from './iconBase';
+import { IconBase, IconProps } from './iconBase';
 
-export const IconDarkMode = styled(Sunset)<IconProps>`
-  ${BaseStyle}
-`;
+export const IconDarkMode: React.FC<IconProps> = (props) => {
+  const Icon = IconBase(Sunset);
+  return <Icon {...props} />;
+};
 
 IconDarkMode.displayName = 'IconDarkMode';

--- a/src/components/ui/icons/iconGitHub.tsx
+++ b/src/components/ui/icons/iconGitHub.tsx
@@ -1,7 +1,7 @@
 import { Github } from '@styled-icons/feather';
-import styled from 'styled-components';
-import { BaseStyle, IconProps } from './iconBase';
+import { IconBase, IconProps } from './iconBase';
 
-export const IconGitHub = styled(Github)<IconProps>`
-  ${BaseStyle}
-`;
+export const IconGitHub: React.FC<IconProps> = (props) => {
+  const Icon = IconBase(Github);
+  return <Icon {...props} />;
+};

--- a/src/components/ui/icons/iconGitHub.tsx
+++ b/src/components/ui/icons/iconGitHub.tsx
@@ -5,3 +5,5 @@ export const IconGitHub: React.FC<IconProps> = (props) => {
   const Icon = IconBase(Github);
   return <Icon {...props} />;
 };
+
+IconGitHub.displayName = 'IconGitHub';

--- a/src/components/ui/icons/iconLightMode.tsx
+++ b/src/components/ui/icons/iconLightMode.tsx
@@ -1,9 +1,9 @@
 import { Sunrise } from '@styled-icons/feather';
-import styled from 'styled-components';
-import { BaseStyle, IconProps } from './iconBase';
+import { IconBase, IconProps } from './iconBase';
 
-export const IconLightMode = styled(Sunrise)<IconProps>`
-  ${BaseStyle}
-`;
+export const IconLightMode: React.FC<IconProps> = (props) => {
+  const Icon = IconBase(Sunrise);
+  return <Icon {...props} />;
+};
 
 IconLightMode.displayName = 'IconLightMode';

--- a/src/components/ui/icons/iconMail.tsx
+++ b/src/components/ui/icons/iconMail.tsx
@@ -5,3 +5,5 @@ export const IconMail: React.FC<IconProps> = (props) => {
   const Icon = IconBase(Mail);
   return <Icon {...props} />;
 };
+
+IconMail.displayName = 'IconMail';

--- a/src/components/ui/icons/iconMail.tsx
+++ b/src/components/ui/icons/iconMail.tsx
@@ -1,7 +1,7 @@
 import { Mail } from '@styled-icons/feather';
-import styled from 'styled-components';
-import { BaseStyle, IconProps } from './iconBase';
+import { IconBase, IconProps } from './iconBase';
 
-export const IconMail = styled(Mail)<IconProps>`
-  ${BaseStyle}
-`;
+export const IconMail: React.FC<IconProps> = (props) => {
+  const Icon = IconBase(Mail);
+  return <Icon {...props} />;
+};


### PR DESCRIPTION
## What this pull request does

This pull request refactors usage of a base icon, which is to be re-used in icon components. Icon components only responsibility now is determine which styled-icon to use. Rest of the props and styles is handled through a base icon component

### Types of changes

- [ ] 🐛 Bug fixes
- [ ] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
