### PR TITLE
Use date-fns to parse and format dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@mdx-js/react": "^1.6.6",
     "@styled-icons/feather": "^10.5.0",
+    "date-fns": "^2.14.0",
     "mdx-prism": "^0.3.1",
     "next": "latest",
     "next-mdx-enhanced": "^3.0.0",

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,1 +1,5 @@
-export const formatDate = (date: string) => new Date(date).toLocaleDateString('sv');
+import { format } from 'date-fns';
+
+const dateFormat = 'yyyy-MM-dd';
+
+export const formatDate = (date: string) => format(new Date(date), dateFormat);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2538,6 +2538,11 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
+date-fns@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.14.0.tgz#359a87a265bb34ef2e38f93ecf63ac453f9bc7ba"
+  integrity sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==
+
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## What this pull request does

This pull request uses date-fns instead of custom date formatter to format dates as `yyyy-MM-dd`

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
