### PR TITLE
Upgrade to latest typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-plugin-import-glob-array": "^0.2.0",
     "babel-plugin-styled-components": "^1.10.0",
     "rehype": "^11.0.0",
-    "typescript": "3.5.2"
+    "typescript": "3.9.6"
   },
   "license": "ISC"
 }

--- a/src/utils/resourcePathToBlogURL.ts
+++ b/src/utils/resourcePathToBlogURL.ts
@@ -1,4 +1,7 @@
-export const resourcePathToBlogURL = (resourcePath: string) => {
-  const blogPath = resourcePath.split('/').pop();
-  return `/blogg/${blogPath ? blogPath.replace('.mdx', '') : ''}`;
+export const resourcePathToBlogURL = (resourcePath: string): string => {
+  const path = resourcePath.split('/').pop()?.replace('.mdx', '');
+  if (!path) {
+    return '';
+  }
+  return `/blogg/${path}`;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6231,10 +6231,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
## What this pull request does

This pull request upgrades typescript `3.5.2` -> `3.9.6`.

Bonus: also uses optional chaining in a util function. 

### Types of changes

- [ ] 🐛 Bug fixes
- [ ] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [x] 🧹 Chores
- [ ] 📝 Documentation
