### PR TITLE
Fix link nested in link error

### DIFF
--- a/src/components/cards/cardProject.tsx
+++ b/src/components/cards/cardProject.tsx
@@ -18,25 +18,25 @@ interface CardProjectProps {
 export const CardProject: React.FC<CardProjectProps> = ({ title, summary, tags, urlSource, url }) => {
   return (
     <Card>
-      <UnstyledLink href={urlSource}>
-        <Row style={{ height: '100%' }}>
-          <MarginSmall />
-          <Column>
+      <Row style={{ height: '100%' }}>
+        <MarginSmall />
+        <Column>
+          <UnstyledLink href={urlSource}>
             <MarginSmall />
             <h3>{title}</h3>
             <MarginSmall />
             <p>{summary}</p>
             <Fill />
-            <Row>
-              {tags && tags.map((tag, index) => <Tag key={tag + index}>{tag}</Tag>)}
-              <Fill />
-              {url && <a href={url}>Visa</a>}
-            </Row>
-            <MarginSmall />
-          </Column>
+          </UnstyledLink>
+          <Row>
+            {tags && tags.map((tag, index) => <Tag key={tag + index}>{tag}</Tag>)}
+            <Fill />
+            {url && <a href={url}>Visa</a>}
+          </Row>
           <MarginSmall />
-        </Row>
-      </UnstyledLink>
+        </Column>
+        <MarginSmall />
+      </Row>
     </Card>
   );
 };


### PR DESCRIPTION
## What this pull request does

This pull request fixes a link nested in link introduced in #28. Links nested in links result in `validateDOMNesting(...): <a> cannot appear as a descendant of <a>.` errors

### Types of changes

- [x] 🐛 Bug fixes
- [ ] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
