### PR TITLE
Make variables of primary brand color variations with help of color package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@mdx-js/react": "^1.6.6",
     "@styled-icons/feather": "^10.5.0",
+    "color": "^3.1.2",
     "date-fns": "^2.14.0",
     "mdx-prism": "^0.3.1",
     "next": "latest",
@@ -23,6 +24,7 @@
     "styled-reset": "^4.1.6"
   },
   "devDependencies": {
+    "@types/color": "^3.0.1",
     "@types/mdx-js__react": "^1.5.2",
     "@types/node": "12.0.12",
     "@types/react": "16.8.23",

--- a/src/theme/parts/colors.ts
+++ b/src/theme/parts/colors.ts
@@ -1,4 +1,10 @@
 import { Colors, ColorTheme } from '../../types/theme/Colors';
+import color from 'color';
+
+const colorPrimary = '#6691FF';
+const colorPrimaryDarken = color(colorPrimary).darken(0.05).hex();
+const colorPrimaryLighten = color(colorPrimary).lighten(0.38).hex();
+const btnShadowOpaqueRatio = 0.35;
 
 const darkTheme: ColorTheme = {
   backgroundColor: '#171923',
@@ -15,13 +21,13 @@ const darkTheme: ColorTheme = {
 const lightTheme: ColorTheme = {
   backgroundColor: '#FFFFFF',
   backgroundColorSecondary: '#FFFFFF',
-  backgroundColorHighlight: '#e9efff',
+  backgroundColorHighlight: colorPrimaryLighten,
   textColor: '#585858',
   textMutedColor: '#BDBDBD',
   headingColor: '#585858',
   boxShadowMain: '0px 4px 10px rgba(0, 0, 0, 0.09)',
-  boxShadowButton: '0px 4px 7px rgba(102, 145, 255, 0.35)',
-  boxShadowButtonHover: '0px 4px 10px rgba(102, 145, 255, 0.35)',
+  boxShadowButton: `0px 4px 7px ${color(colorPrimary).lighten(0.25).opaquer(btnShadowOpaqueRatio)}`,
+  boxShadowButtonHover: `0px 4px 10px ${color(colorPrimary).lighten(0.1).opaquer(btnShadowOpaqueRatio)}`,
 };
 
 export const colors: Colors = {
@@ -30,8 +36,8 @@ export const colors: Colors = {
     dark: darkTheme,
   },
   brand: {
-    primary: '#6691FF',
-    primaryDarken: '#5477D3',
-    primaryLighten: '#e9efff',
+    primary: colorPrimary,
+    primaryDarken: colorPrimaryDarken,
+    primaryLighten: colorPrimaryLighten,
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,10 +1158,24 @@
     "@emotion/is-prop-valid" "^0.8.7"
     tslib "^2.0.0"
 
-"@types/color-name@^1.1.1":
+"@types/color-convert@*":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-1.9.0.tgz#bfa8203e41e7c65471e9841d7e306a7cd8b5172d"
+  integrity sha512-OKGEfULrvSL2VRbkl/gnjjgbbF7ycIlpSsX7Nkab4MOWi5XxmgBYvuiQ7lcCFY5cPDz7MUNaKgxte2VRmtr4Fg==
+  dependencies:
+    "@types/color-name" "*"
+
+"@types/color-name@*", "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+"@types/color@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.1.tgz#2900490ed04da8116c5058cd5dba3572d5a25071"
+  integrity sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==
+  dependencies:
+    "@types/color-convert" "*"
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -2321,7 +2335,7 @@ color-string@^1.5.2:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.0.0:
+color@^3.0.0, color@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
   integrity sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==


### PR DESCRIPTION
## What this pull request does

This pull request changes primary color variation (lighter and darker) declarations to be dependant on the primary color. 

Previously the light variant was a hard-coded hex value of a color "that seemed" like a lighter variant of the primary color. 

Now, however, the light variant is an **actual** lighter variant of the primary color with the primary color - with the help of color package: `const colorPrimaryLighten = color(colorPrimary).lighten(0.38).hex()`

This means primary variations are more in sync with the actual primary color. Change that and the variations will adapt. 

### Types of changes

- [ ] 🐛 Bug fixes
- [ ] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
