### PR TITLE
Move blog post fetching into data folder and refactor getting prev/next blog post into custom hook

### DIFF
--- a/src/data/blogPosts.ts
+++ b/src/data/blogPosts.ts
@@ -10,18 +10,8 @@ const toPostMetaData = (frontMatter: PostFrontMatter): PostMetaData => ({
   url: resourcePathToBlogURL(frontMatter.__resourcePath),
 });
 
-const hasMatchingResourcePath = (resourcePath: string) => (post: PostMetaData) => post.__resourcePath === resourcePath;
-
 export const getAllBlogPosts = (): PostMetaData[] => {
   const blogPosts = (frontMatter as unknown) as PostFrontMatter[];
   const sortedBlogPosts = blogPosts.sort(sortBlogPostsAscByDate);
   return sortedBlogPosts.map(toPostMetaData);
-};
-
-export const getPrevAndNextPost = (frontMatter: PostFrontMatter): PostMetaData[] => {
-  const allPosts = getAllBlogPosts();
-  const currentBlogPostIndex = allPosts.findIndex(hasMatchingResourcePath(frontMatter.__resourcePath));
-  const prevPost = allPosts[currentBlogPostIndex + 1];
-  const nextPost = allPosts[currentBlogPostIndex - 1];
-  return [prevPost, nextPost];
 };

--- a/src/data/blogPosts.ts
+++ b/src/data/blogPosts.ts
@@ -1,8 +1,8 @@
 import { frontMatter } from '../pages/blogg/*.mdx';
 import { PostFrontMatter, PostMetaData } from '../types/FrontMatter';
-import { sortBlogPostsAscByDate } from './sortBlogPostsByDate';
-import { resourcePathToBlogURL } from './resourcePathToBlogURL';
-import { formatDate } from './formatDate';
+import { sortBlogPostsAscByDate } from '../utils/sortBlogPostsByDate';
+import { resourcePathToBlogURL } from '../utils/resourcePathToBlogURL';
+import { formatDate } from '../utils/formatDate';
 
 const toPostMetaData = (frontMatter: PostFrontMatter): PostMetaData => ({
   ...frontMatter,

--- a/src/hooks/usePrevAndNextBlogPost.ts
+++ b/src/hooks/usePrevAndNextBlogPost.ts
@@ -1,0 +1,12 @@
+import { PostFrontMatter, PostMetaData } from '../types/FrontMatter';
+import { useContent } from '../context/ContentContext';
+
+const hasMatchingResourcePath = (resourcePath: string) => (post: PostMetaData) => post.__resourcePath === resourcePath;
+
+export const usePrevAndNextBlogPost = (currentPost: PostFrontMatter): PostMetaData[] => {
+  const { blogPosts } = useContent();
+  const currentBlogPostIndex = blogPosts.findIndex(hasMatchingResourcePath(currentPost.__resourcePath));
+  const prevPost = blogPosts[currentBlogPostIndex + 1];
+  const nextPost = blogPosts[currentBlogPostIndex - 1];
+  return [prevPost, nextPost];
+};

--- a/src/layouts/blogPost.tsx
+++ b/src/layouts/blogPost.tsx
@@ -11,7 +11,7 @@ import { MarginMedium } from '../components/ui/margins/marginMedium';
 import { theme } from '../theme/theme';
 import { PostFrontMatter } from '../types/FrontMatter';
 import { formatDate } from '../utils/formatDate';
-import { getPrevAndNextPost } from '../data/blogPosts';
+import { usePrevAndNextBlogPost } from '../hooks/usePrevAndNextBlogPost';
 
 interface PostProps {
   children: React.ReactChildren;
@@ -20,7 +20,7 @@ interface PostProps {
 export default (frontMatter: PostFrontMatter) => {
   // eslint-disable-next-line react/display-name
   return ({ children }: PostProps) => {
-    const [prevPost, nextPost] = getPrevAndNextPost(frontMatter);
+    const [prevPost, nextPost] = usePrevAndNextBlogPost(frontMatter);
 
     return (
       <>

--- a/src/layouts/blogPost.tsx
+++ b/src/layouts/blogPost.tsx
@@ -11,7 +11,7 @@ import { MarginMedium } from '../components/ui/margins/marginMedium';
 import { theme } from '../theme/theme';
 import { PostFrontMatter } from '../types/FrontMatter';
 import { formatDate } from '../utils/formatDate';
-import { getPrevAndNextPost } from '../utils/getBlogPosts';
+import { getPrevAndNextPost } from '../data/blogPosts';
 
 interface PostProps {
   children: React.ReactChildren;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import SEO from '../../next-seo.config';
 import { MDXComponents } from '../components/mdxComponents';
 import { ContentProvider } from '../context/ContentContext';
 import { projects } from '../data/projects';
-import { getAllBlogPosts } from '../utils/getBlogPosts';
+import { getAllBlogPosts } from '../data/blogPosts';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (


### PR DESCRIPTION
## What this pull request does

This pull request moves the functionality of fetching posts from utils folder -> data folder since blog posts is a data source.

This pull request also refactors functionality of getting prev/next blog post into a custom hook.

Benefit of using a custom hook to get prev/next post is that the custom hook can get blog posts that are already stored in context via `useContent()` hook. Previous implementation of getting prev/next post called `getAllBlogPosts()` once more which is unnecessary since all posts are already stored in context. **_Now the functionality of traversing through all blog posts to find prev/next is seperated from the data source._**

### Types of changes

- [ ] 🐛 Bug fixes
- [ ] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
