### PR TITLE
Add prev/next arrows to blog post cards

### DIFF
--- a/src/layouts/blogPost.tsx
+++ b/src/layouts/blogPost.tsx
@@ -39,8 +39,8 @@ export default (frontMatter: PostFrontMatter) => {
                 <MarginMedium />
                 <h2>Mer innehåll</h2>
                 <ResponsiveGrid itemWidth="250px" gutter={theme.margins.large}>
-                  {prevPost && <CardPost subHeader="Föregående" post={prevPost} />}
-                  {nextPost && <CardPost subHeader="Nästa" post={nextPost} />}
+                  {prevPost && <CardPost subHeader="&larr; Föregående" post={prevPost} />}
+                  {nextPost && <CardPost subHeader="Nästa &rarr;" post={nextPost} />}
                 </ResponsiveGrid>
               </>
             )}


### PR DESCRIPTION
## What this pull request does

This pull request adds html entities arrows for prev/next blog post cards in `layouts/blogPost.tsx` template

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
