### PR TITLE
Animate dark mode toggle switch icons

### DIFF
--- a/src/components/navbar/darkModeToggleIcons.tsx
+++ b/src/components/navbar/darkModeToggleIcons.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { motion, MotionProps } from 'framer-motion';
+import React, { useState } from 'react';
+import { motion, MotionProps, Variants, Transition } from 'framer-motion';
 import { IconLightMode } from '../ui/icons/iconLightMode';
 import { IconDarkMode } from '../ui/icons/iconDarkMode';
 
@@ -8,26 +8,43 @@ interface DarkModeToggleIconsProps {
   onToggle: () => void;
 }
 
+const transitionType: Transition = {
+  type: 'tween',
+  duration: 0.2,
+  ease: 'easeInOut',
+};
+
 const animation: MotionProps = {
   whileHover: { y: -2 },
   whileTap: { y: 0 },
-  transition: {
-    type: 'tween',
-    duration: 0.3,
-    ease: 'easeInOut',
-  },
+  transition: transitionType,
   initial: false,
 };
 
-const variants = {
-  dark: { rotate: -360 },
-  light: { rotate: 360 },
+const variants: Variants = {
+  dark: { rotate: -360, ...transitionType },
+  light: { rotate: 360, ...transitionType },
 };
 
 export const DarkModeToggleIcons: React.FC<DarkModeToggleIconsProps> = ({ isDarkMode, onToggle }) => {
+  const [hasUserToggled, userToggle] = useState(false);
+  const toggleDarkMode = () => {
+    if (!hasUserToggled) {
+      userToggle(true);
+    }
+    onToggle();
+  };
+
+  const shouldRenderDarkVariant = isDarkMode && hasUserToggled;
+  const shouldrenderLightVariant = !isDarkMode && hasUserToggled;
+
   return (
-    <motion.div {...animation} animate={isDarkMode ? 'dark' : 'light'} variants={variants}>
-      {isDarkMode ? <IconLightMode onClick={onToggle} /> : <IconDarkMode onClick={onToggle} />}
+    <motion.div
+      {...animation}
+      animate={shouldRenderDarkVariant ? 'dark' : shouldrenderLightVariant ? 'light' : ''}
+      variants={variants}
+    >
+      {isDarkMode ? <IconLightMode onClick={toggleDarkMode} /> : <IconDarkMode onClick={toggleDarkMode} />}
     </motion.div>
   );
 };

--- a/src/components/navbar/darkModeToggleIcons.tsx
+++ b/src/components/navbar/darkModeToggleIcons.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { motion, MotionProps } from 'framer-motion';
+import { IconLightMode } from '../ui/icons/iconLightMode';
+import { IconDarkMode } from '../ui/icons/iconDarkMode';
+
+interface DarkModeToggleIconsProps {
+  isDarkMode: boolean;
+  onToggle: () => void;
+}
+
+const animation: MotionProps = {
+  whileHover: { y: -2 },
+  whileTap: { y: 0 },
+  transition: {
+    type: 'tween',
+    duration: 0.3,
+    ease: 'easeInOut',
+  },
+  initial: false,
+};
+
+const variants = {
+  dark: { rotate: -360 },
+  light: { rotate: 360 },
+};
+
+export const DarkModeToggleIcons: React.FC<DarkModeToggleIconsProps> = ({ isDarkMode, onToggle }) => {
+  return (
+    <motion.div {...animation} animate={isDarkMode ? 'dark' : 'light'} variants={variants}>
+      {isDarkMode ? <IconLightMode onClick={onToggle} /> : <IconDarkMode onClick={onToggle} />}
+    </motion.div>
+  );
+};
+
+DarkModeToggleIcons.displayName = 'DarkModeToggleIcons';

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -4,9 +4,8 @@ import { Fill } from '../ui/container/fill';
 import { ResponsiveContainer } from '../ui/container/responsiveContainer';
 import { Row } from '../ui/container/row';
 import { UnstyledInternalLink } from '../ui/content/unstyledLink';
-import { IconDarkMode } from '../ui/icons/iconDarkMode';
-import { IconLightMode } from '../ui/icons/iconLightMode';
 import { MarginMedium } from '../ui/margins/marginMedium';
+import { DarkModeToggleIcons } from './darkModeToggleIcons';
 import { NavbarContentWrapper, NavbarItem, NavbarWrapper } from './nav.styles';
 
 export const Navbar = () => {
@@ -25,7 +24,7 @@ export const Navbar = () => {
               <NavbarItem>Blogg</NavbarItem>
             </UnstyledInternalLink>
             <MarginMedium />
-            {isDarkMode ? <IconLightMode onClick={toggleDarkMode} /> : <IconDarkMode onClick={toggleDarkMode} />}
+            <DarkModeToggleIcons isDarkMode={isDarkMode} onToggle={toggleDarkMode} />
           </Row>
         </NavbarContentWrapper>
       </ResponsiveContainer>


### PR DESCRIPTION
## What this pull request does

This pull request adds animation through framer motion to animate icon switch between dark/light mode in navbar:
* Refactor icon rendering and animations into own component - `DarkModeToggleIcons` that takes props to render icons and handle callback prop on click.

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
