### PR TITLE
Add motion animation to button component with styled.attrs

### DIFF
--- a/src/components/ui/buttons/ButtonPrimary.tsx
+++ b/src/components/ui/buttons/ButtonPrimary.tsx
@@ -1,6 +1,17 @@
 import styled from 'styled-components';
+import { motion, MotionProps } from 'framer-motion';
 
-export const ButtonPrimary = styled.div`
+const animation: MotionProps = {
+  whileHover: { y: -1 },
+  whileTap: { y: 2 },
+  transition: {
+    type: 'spring',
+    stiffness: 300,
+    damping: 10,
+  },
+};
+
+export const ButtonPrimary = styled(motion.div).attrs({ ...animation })`
   background: var(--primary-color);
   color: white;
   padding: 16px 20px;
@@ -8,12 +19,11 @@ export const ButtonPrimary = styled.div`
   font-weight: bold;
   border-radius: var(--border-radius);
   box-shadow: var(--box-shadow-button);
-  transition: transform 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
   cursor: pointer;
   width: auto;
   display: inline-block;
   &:hover {
-    transform: translateY(-1px);
     background: var(--primary-color-darken);
     box-shadow: var(--box-shadow-button-hover);
   }


### PR DESCRIPTION
## What this pull request does

This pull request changes styled button component to animate it's position on hover with framer motion. This means easier animation while tapping button aswell. 

All instances of this component has the same animation "baked in" due to `styled(motion.div).attrs({ ...animation })` where animation props are spread directly as props

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
