### PR TITLE
Add 'Quicksand' as custom content font

### DIFF
--- a/src/components/cards/cardPost.tsx
+++ b/src/components/cards/cardPost.tsx
@@ -7,6 +7,7 @@ import { TextMuted } from '../ui/content/textMuted';
 import styled from 'styled-components';
 import { UnstyledInternalLink } from '../ui/content/unstyledLink';
 import { animationSpring } from './animations';
+import { CardHeader } from './shared.styles';
 
 const SubHeader = styled(TextMuted)`
   font-size: var(--font-size-smaller);
@@ -25,7 +26,7 @@ export const CardPost: React.FC<CardPostProps> = ({ post, subHeader }) => (
         <Column style={{ alignItems: 'stretch' }}>
           <MarginSmall />
           {subHeader && <SubHeader>{subHeader}</SubHeader>}
-          <h3 style={{ marginTop: '0' }}>{post.title}</h3>
+          <CardHeader style={{ marginTop: '0' }}>{post.title}</CardHeader>
           <TextMuted>{post.date}</TextMuted>
         </Column>
         <MarginSmall />

--- a/src/components/cards/cardProject.tsx
+++ b/src/components/cards/cardProject.tsx
@@ -7,6 +7,7 @@ import { Tag } from '../ui/content/tag';
 import { MarginSmall } from '../ui/margins/marginSmall';
 import { UnstyledLink } from '../ui/content/unstyledLink';
 import { animationSpring } from './animations';
+import { CardHeader } from './shared.styles';
 
 interface CardProjectProps {
   title: string;
@@ -24,7 +25,7 @@ export const CardProject: React.FC<CardProjectProps> = ({ title, summary, tags, 
         <Column>
           <UnstyledLink href={urlSource}>
             <MarginSmall />
-            <h3>{title}</h3>
+            <CardHeader>{title}</CardHeader>
             <MarginSmall />
             <p>{summary}</p>
           </UnstyledLink>

--- a/src/components/cards/shared.styles.ts
+++ b/src/components/cards/shared.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const CardHeader = styled.h3`
+  font-weight: bold;
+`;
+
+CardHeader.displayName = 'CardHeader';

--- a/src/components/ui/content/textMuted.tsx
+++ b/src/components/ui/content/textMuted.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const TextMuted = styled.p`
   color: var(--text-muted-color);
   font-size: var(--font-size-small);
+  font-weight: 400;
 `;
 
 TextMuted.displayName = 'TextMuted';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,6 +20,10 @@ function MyApp({ Component, pageProps }: AppProps) {
       <Head>
         <meta name="viewport" content="initial-scale=1.0, width=device-width" />
         <link
+          href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;700&display=swap"
+          rel="stylesheet"
+        />
+        <link
           rel="icon"
           href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>👨‍💻</text></svg>"
         />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,6 @@ import { Project } from '../types/Project';
 const HeroTitle = styled.h1`
   display: inline-block;
   transform: skewY(-4deg);
-  font-style: italic;
 `;
 
 export default function Home() {

--- a/src/theme/globalStyle.tsx
+++ b/src/theme/globalStyle.tsx
@@ -19,6 +19,7 @@ export const GlobalStyle = createGlobalStyle`
     background: var(--bg-color);
     color: var(--text-color);
     font-family: var(--content-font);
+    font-weight: 500;
   }
 
   /* Add typography styles */

--- a/src/theme/parts/fonts.ts
+++ b/src/theme/parts/fonts.ts
@@ -2,8 +2,8 @@ import { Fonts } from '../../types/theme/Fonts';
 
 export const fonts: Fonts = {
   fontFamily: {
-    main: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`,
-    headings: `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`,
+    main: `'Quicksand', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`,
+    headings: `'Quicksand', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;`,
     mono: `'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace`,
   },
   size: {

--- a/src/theme/syntaxHighlighting.ts
+++ b/src/theme/syntaxHighlighting.ts
@@ -9,6 +9,7 @@ export const syntaxHighlighting = css`
     display: block;
     font-family: ${theme.fonts.fontFamily.mono};
     text-align: left;
+    font-weight: 400;
     white-space: pre;
     word-spacing: normal;
     word-break: normal;
@@ -135,7 +136,7 @@ export const syntaxHighlighting = css`
     overflow-y: hidden;
     font-family: ${theme.fonts.fontFamily.main};
     margin-bottom: -0.8rem;
-    font-weight: bold;
+    font-weight: 500;
     padding: 0.5em 1em;
     background: #81a1c1;
     color: #f8f8f2;

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -19,13 +19,13 @@ export const typography = css`
     font-size: var(--font-size-h1);
     margin-top: 1rem;
     margin-bottom: 1rem;
-    font-weight: bold;
+    font-weight: 700;
   }
   h2 {
     font-size: var(--font-size-h2);
     margin-top: 1rem;
     margin-bottom: 1rem;
-    font-weight: bold;
+    font-weight: 700;
   }
   h3 {
     font-size: var(--font-size-h3);
@@ -116,6 +116,7 @@ export const typography = css`
     color: var(--text-color);
     background: var(--bg-color-highlight);
     border-radius: var(--border-radius-small);
+    font-weight: 400;
     padding: 4px;
   }
 

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -13,6 +13,7 @@ export const typography = css`
     font-family: var(--headings-font);
     color: var(--heading-color);
     line-height: 1.2;
+    letter-spacing: -0.5px;
   }
 
   h1 {


### PR DESCRIPTION
## What this pull request does

This pull request adds the font 'Quicksand' - from the google api to use as main content font.

Previously the font used were **only** system fonts. But now the system fonts are used as fallback.

Bonus: Adjusted some font weights 

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
