### PR TITLE
Fix seo title for default layout

### DIFF
--- a/src/components/seo/seoBlogPost.tsx
+++ b/src/components/seo/seoBlogPost.tsx
@@ -1,14 +1,13 @@
 import { PostFrontMatter } from '../../types/FrontMatter';
-import { site } from '../../data/site';
-import { NextSeo } from 'next-seo';
+import { Seo } from './seo';
 
 interface SeoBlogPostProps {
   blogPostData: PostFrontMatter;
 }
 
 export const SeoBlogPost: React.FC<SeoBlogPostProps> = ({ blogPostData: { title, summary, date } }) => (
-  <NextSeo
-    title={`${title} – ${site.author}`}
+  <Seo
+    title={title}
     description={summary}
     openGraph={{
       type: 'article',

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -3,18 +3,17 @@ import { FrontMatterBase } from '../types/FrontMatter';
 import { ResponsiveContainer } from '../components/ui/container/responsiveContainer';
 import { MarginLarge } from '../components/ui/margins/marginLarge';
 import { Seo } from '../components/seo/seo';
-import { title } from 'process';
 
 interface DefaultProps {
   children: React.ReactChildren;
 }
 
-const layoutDefault = (_frontMatter: FrontMatterBase) => {
+const layoutDefault = (frontMatter: FrontMatterBase) => {
   // eslint-disable-next-line react/display-name
   return ({ children }: DefaultProps) => {
     return (
       <>
-        <Seo title={title} />
+        <Seo title={frontMatter.title} />
         <ResponsiveContainer>
           <MarginLarge />
           {children}


### PR DESCRIPTION
## What this pull request does

This pull request fixes a bug in default layout page where wrong title were passed to `<Seo />` component. Frontmatter title should be passsed to the component

**Bonus:** `SeoBlogPost` now uses the `Seo` component internally. This means that SeoBlogPost does not have to take site title in consideration.

### Types of changes

- [x] 🐛    Bug fixes
- [ ] 💅  New features
- [x] 🚧  Code refactoring
- [ ] 📜  Article
- [ ] 🧹  Chores
- [ ] 📝  Documentation
