### PR TITLE
Usege of a hook to set initial theme to dark if user has system wide dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^16.13.0",
     "remark-code-titles": "^0.1.1",
     "styled-components": "^5.0.0",
-    "styled-reset": "^4.1.6"
+    "styled-reset": "^4.1.6",
+    "use-media": "^1.4.0"
   },
   "devDependencies": {
     "@types/color": "^3.0.1",

--- a/src/components/navbar/darkModeToggleIcons.tsx
+++ b/src/components/navbar/darkModeToggleIcons.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
+import { IconAnimation } from '../../types/icon/iconAnimation';
 import { IconDarkMode } from '../ui/icons/iconDarkMode';
 import { IconLightMode } from '../ui/icons/iconLightMode';
-import { IconAnimation } from '../../types/icon/iconAnimation';
 
 interface DarkModeToggleIconsProps {
   isDarkMode: boolean;
@@ -16,19 +16,9 @@ export const DarkModeToggleIcons: React.FC<DarkModeToggleIconsProps> = ({ isDark
     }
     onToggle();
   };
-
-  const shouldRenderDarkVariant = isDarkMode && hasUserToggled;
-  const shouldrenderLightVariant = !isDarkMode && hasUserToggled;
-  const animation = shouldRenderDarkVariant
-    ? IconAnimation.RotateLeft
-    : shouldrenderLightVariant
-    ? IconAnimation.RotateRight
-    : IconAnimation.None;
-  return isDarkMode ? (
-    <IconLightMode onClick={toggleDarkMode} animation={animation} />
-  ) : (
-    <IconDarkMode onClick={toggleDarkMode} animation={animation} />
-  );
+  const animation = hasUserToggled ? IconAnimation.RotateRight : IconAnimation.None;
+  const Icon = isDarkMode ? IconLightMode : IconDarkMode;
+  return <Icon onClick={toggleDarkMode} animation={animation} />;
 };
 
 DarkModeToggleIcons.displayName = 'DarkModeToggleIcons';

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -19,9 +19,8 @@ export const useDarkMode = () => {
   };
 
   useEffect(() => {
-    // If user prefers dark mode and no user-stored preference is set
-    // then toggle dark mode to true and add the dark mode class to DOM body
-    // without setting storage pref - only user action through this hook's toggleDarkMode should set to storage
+    // If user prefers dark mode and no user-stored preference is set then change theme to dark
+    // without persisting theme to storage since only user action should persist to storage
     if (prefersDarkMode && !storage.has(themeStorageKey)) {
       toggle(true);
       document.body.classList.add(darkModeClass);

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -4,7 +4,7 @@ import { site } from '../data/site';
 import { storage } from '../utils/storage';
 import { Theme } from '../types/theme/Colors';
 
-const storage_key = `${site.author} - theme`;
+const themeStorageKey = `${site.author} - theme`;
 const darkModeClass = 'dark-mode';
 
 const usePrefersDarkMode = (): boolean => useMedia('(prefers-color-scheme: dark)');
@@ -14,7 +14,7 @@ export const useDarkMode = () => {
   const prefersDarkMode = usePrefersDarkMode();
   const toggleDarkMode = (): void => {
     toggle(!isDarkMode);
-    storage.set(storage_key, isDarkMode ? Theme.Light : Theme.Dark);
+    storage.set(themeStorageKey, isDarkMode ? Theme.Light : Theme.Dark);
     document.body.classList.toggle(darkModeClass);
   };
 
@@ -22,14 +22,14 @@ export const useDarkMode = () => {
     // If user prefers dark mode and no user-stored preference is set
     // then toggle dark mode to true and add the dark mode class to DOM body
     // without setting storage pref - only user action through this hook's toggleDarkMode should set to storage
-    if (prefersDarkMode && !storage.has(storage_key)) {
+    if (prefersDarkMode && !storage.has(themeStorageKey)) {
       toggle(true);
       document.body.classList.add(darkModeClass);
     }
   }, [prefersDarkMode]);
 
   useEffect(() => {
-    if (storage.get(storage_key) === Theme.Dark) {
+    if (storage.get(themeStorageKey) === Theme.Dark) {
       toggleDarkMode();
     }
   }, []);

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -6,7 +6,8 @@ import { Theme } from '../types/theme/Colors';
 
 const storage_key = `${site.author} - theme`;
 const darkModeClass = 'dark-mode';
-const usePrefersDarkMode = () => useMedia('(prefers-color-scheme: dark)');
+
+const usePrefersDarkMode = (): boolean => useMedia('(prefers-color-scheme: dark)');
 
 export const useDarkMode = () => {
   const [isDarkMode, toggle] = useState<boolean>(false);
@@ -18,7 +19,7 @@ export const useDarkMode = () => {
   };
 
   useEffect(() => {
-    // If user prefers dark mode and no user stored preference is set
+    // If user prefers dark mode and no user-stored preference is set
     // then toggle dark mode to true and add the dark mode class to DOM body
     // without setting storage pref - only user action through this hook's toggleDarkMode should set to storage
     if (prefersDarkMode && !storage.has(storage_key)) {

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -2,22 +2,18 @@ import { useState, useEffect } from 'react';
 import { useMedia } from 'use-media';
 import { site } from '../data/site';
 import { storage } from '../utils/storage';
+import { Theme } from '../types/theme/Colors';
 
 const storage_key = `${site.author} - theme`;
 const darkModeClass = 'dark-mode';
 const usePrefersDarkMode = () => useMedia('(prefers-color-scheme: dark)');
-
-enum ThemeState {
-  Dark = 'dark',
-  Light = 'light',
-}
 
 export const useDarkMode = () => {
   const [isDarkMode, toggle] = useState<boolean>(false);
   const prefersDarkMode = usePrefersDarkMode();
   const toggleDarkMode = (): void => {
     toggle(!isDarkMode);
-    storage.set(storage_key, isDarkMode ? ThemeState.Light : ThemeState.Dark);
+    storage.set(storage_key, isDarkMode ? Theme.Light : Theme.Dark);
     document.body.classList.toggle(darkModeClass);
   };
 
@@ -32,7 +28,7 @@ export const useDarkMode = () => {
   }, [prefersDarkMode]);
 
   useEffect(() => {
-    if (storage.get(storage_key) === ThemeState.Dark) {
+    if (storage.get(storage_key) === Theme.Dark) {
       toggleDarkMode();
     }
   }, []);

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,20 +1,38 @@
 import { useState, useEffect } from 'react';
+import { useMedia } from 'use-media';
 import { site } from '../data/site';
 import { storage } from '../utils/storage';
 
-const storage_key = `${site.author} - dark-mode`;
+const storage_key = `${site.author} - theme`;
+const darkModeClass = 'dark-mode';
+const usePrefersDarkMode = () => useMedia('(prefers-color-scheme: dark)');
+
+enum ThemeState {
+  Dark = 'dark',
+  Light = 'light',
+}
 
 export const useDarkMode = () => {
   const [isDarkMode, toggle] = useState<boolean>(false);
-
+  const prefersDarkMode = usePrefersDarkMode();
   const toggleDarkMode = (): void => {
-    storage.set(storage_key, isDarkMode ? 'false' : 'true');
-    document.body.classList.toggle('dark-mode');
     toggle(!isDarkMode);
+    storage.set(storage_key, isDarkMode ? ThemeState.Light : ThemeState.Dark);
+    document.body.classList.toggle(darkModeClass);
   };
 
   useEffect(() => {
-    if (storage.get(storage_key) === 'true') {
+    // If user prefers dark mode and no user stored preference is set
+    // then toggle dark mode to true and add the dark mode class to DOM body
+    // without setting storage pref - only user action through this hook's toggleDarkMode should set to storage
+    if (prefersDarkMode && !storage.has(storage_key)) {
+      toggle(true);
+      document.body.classList.add(darkModeClass);
+    }
+  }, [prefersDarkMode]);
+
+  useEffect(() => {
+    if (storage.get(storage_key) === ThemeState.Dark) {
       toggleDarkMode();
     }
   }, []);

--- a/src/types/theme/Colors.ts
+++ b/src/types/theme/Colors.ts
@@ -1,3 +1,7 @@
+export enum Theme {
+  Dark = 'dark',
+  Light = 'light',
+}
 export interface ColorTheme {
   backgroundColor: string;
   backgroundColorSecondary: string;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,11 @@
-export const storage = {
-  set: (key: string, value: string) => window.localStorage.setItem(key, value),
-  get: (key: string) => window.localStorage.getItem(key),
-  has: (key: string) => !!window.localStorage.getItem(key),
+interface Storage {
+  set: (key: string, value: string) => void;
+  get: (key: string) => string;
+  has: (key: string) => boolean;
+}
+
+export const storage: Storage = {
+  set: (key, value) => window.localStorage.setItem(key, value),
+  get: (key) => window.localStorage.getItem(key) ?? '',
+  has: (key) => !!window.localStorage.getItem(key),
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,5 @@
 export const storage = {
   set: (key: string, value: string) => window.localStorage.setItem(key, value),
   get: (key: string) => window.localStorage.getItem(key),
+  has: (key: string) => !!window.localStorage.getItem(key),
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7323,6 +7323,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-media@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/use-media/-/use-media-1.4.0.tgz#e777bf1f382a7aacabbd1f9ce3da2b62e58b2a98"
+  integrity sha512-XsgyUAf3nhzZmEfhc5MqLHwyaPjs78bgytpVJ/xDl0TF4Bptf3vEpBNBBT/EIKOmsOc8UbuECq3mrP3mt1QANA==
+
 use-subscription@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.1.tgz#edcbcc220f1adb2dd4fa0b2f61b6cc308e620069"


### PR DESCRIPTION
## What this pull request does

This pull request adds functionality to pick up if a user has system dark mode turned on or not - and switch theme to dark mode if true. This functionality is implemented by:
* Refactor `src/hooks/useDarkMode.ts` to use a `useMedia` hook from the use-media npm package to determine if user prefers dark mode
   * Prev. it only defaulted to light mode - even if user has system wide dark mode activated.
   * UseEffect to switch to dark mode if user prefers it.
   * Value will **not** be saved in localStorage - only active user action of switching theme should persist to localStorage.
* Refactor what value is stored in localStorage for dark mode. It's not true/false anymore but values in a `Theme` enum.
* More simple logic for dark/light icons and animations 

**Bonus:**
* Interfacify storage utility object

### Types of changes

- [ ] 🐛  Bug fixes
- [x] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
