### PR TITLE
Refactor margin components

### DIFF
--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -4,7 +4,7 @@ import { Fill } from '../ui/container/fill';
 import { ResponsiveContainer } from '../ui/container/responsiveContainer';
 import { Row } from '../ui/container/row';
 import { UnstyledInternalLink } from '../ui/content/unstyledLink';
-import { MarginMedium } from '../ui/margins/marginMedium';
+import { MarginSmall } from '../ui/margins/marginSmall';
 import { DarkModeToggleIcons } from './darkModeToggleIcons';
 import { NavbarContentWrapper, NavbarItem, NavbarWrapper } from './nav.styles';
 
@@ -23,7 +23,7 @@ export const Navbar = () => {
             <UnstyledInternalLink href="/blogg">
               <NavbarItem>Blogg</NavbarItem>
             </UnstyledInternalLink>
-            <MarginMedium />
+            <MarginSmall />
             <DarkModeToggleIcons isDarkMode={isDarkMode} onToggle={toggleDarkMode} />
           </Row>
         </NavbarContentWrapper>

--- a/src/components/ui/margins/margin.tsx
+++ b/src/components/ui/margins/margin.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+import { Spacing } from '../../../types/theme/Spacing';
+import { margins } from '../../../theme/parts/margins';
+
+interface MarginProps {
+  size: Spacing;
+}
+
+const MarginComponent = styled.div<{ size: string }>`
+  max-width: ${(props) => props.size};
+  min-width: ${(props) => props.size};
+  margin: ${(props) => props.size};
+  display: flex;
+`;
+
+MarginComponent.displayName = 'MarginComponent';
+
+export const Margin: React.FC<MarginProps> = ({ size }) => <MarginComponent size={margins[size]} />;
+
+Margin.displayName = 'Margin';

--- a/src/components/ui/margins/marginLarge.tsx
+++ b/src/components/ui/margins/marginLarge.tsx
@@ -1,10 +1,4 @@
-import styled from 'styled-components';
+import { Margin } from './margin';
+import { Spacing } from '../../../types/theme/Spacing';
 
-export const MarginLarge = styled.div`
-  max-width: var(--margin-large);
-  min-width: var(--margin-large);
-  display: flex;
-  margin: var(--margin-large);
-`;
-
-MarginLarge.displayName = 'MarginLarge';
+export const MarginLarge = () => <Margin size={Spacing.Large} />;

--- a/src/components/ui/margins/marginLarge.tsx
+++ b/src/components/ui/margins/marginLarge.tsx
@@ -1,4 +1,6 @@
 import { Margin } from './margin';
 import { Spacing } from '../../../types/theme/Spacing';
 
-export const MarginLarge = () => <Margin size={Spacing.Large} />;
+export const MarginLarge: React.FC = () => <Margin size={Spacing.Large} />;
+
+MarginLarge.displayName = 'MarginLarge';

--- a/src/components/ui/margins/marginLarge.tsx
+++ b/src/components/ui/margins/marginLarge.tsx
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
 export const MarginLarge = styled.div`
+  max-width: var(--margin-large);
+  min-width: var(--margin-large);
+  display: flex;
   margin: var(--margin-large);
 `;
 

--- a/src/components/ui/margins/marginMedium.tsx
+++ b/src/components/ui/margins/marginMedium.tsx
@@ -1,10 +1,4 @@
-import styled from 'styled-components';
+import { Margin } from './margin';
+import { Spacing } from '../../../types/theme/Spacing';
 
-export const MarginMedium = styled.div`
-  max-width: var(--margin-medium);
-  min-width: var(--margin-medium);
-  margin: var(--margin-medium);
-  display: flex;
-`;
-
-MarginMedium.displayName = 'MarginMedium';
+export const MarginMedium = () => <Margin size={Spacing.Medium} />;

--- a/src/components/ui/margins/marginMedium.tsx
+++ b/src/components/ui/margins/marginMedium.tsx
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 
 export const MarginMedium = styled.div`
+  max-width: var(--margin-medium);
+  min-width: var(--margin-medium);
   margin: var(--margin-medium);
+  display: flex;
 `;
 
 MarginMedium.displayName = 'MarginMedium';

--- a/src/components/ui/margins/marginMedium.tsx
+++ b/src/components/ui/margins/marginMedium.tsx
@@ -1,4 +1,6 @@
 import { Margin } from './margin';
 import { Spacing } from '../../../types/theme/Spacing';
 
-export const MarginMedium = () => <Margin size={Spacing.Medium} />;
+export const MarginMedium: React.FC = () => <Margin size={Spacing.Medium} />;
+
+MarginMedium.displayName = 'MarginMedium';

--- a/src/components/ui/margins/marginSmall.tsx
+++ b/src/components/ui/margins/marginSmall.tsx
@@ -1,10 +1,4 @@
-import styled from 'styled-components';
+import { Margin } from './margin';
+import { Spacing } from '../../../types/theme/Spacing';
 
-export const MarginSmall = styled.div`
-  max-width: var(--margin-small);
-  min-width: var(--margin-small);
-  margin: var(--margin-small);
-  display: flex;
-`;
-
-MarginSmall.displayName = 'MarginSmall';
+export const MarginSmall = () => <Margin size={Spacing.Small} />;

--- a/src/components/ui/margins/marginSmall.tsx
+++ b/src/components/ui/margins/marginSmall.tsx
@@ -1,4 +1,6 @@
 import { Margin } from './margin';
 import { Spacing } from '../../../types/theme/Spacing';
 
-export const MarginSmall = () => <Margin size={Spacing.Small} />;
+export const MarginSmall: React.FC = () => <Margin size={Spacing.Small} />;
+
+MarginSmall.displayName = 'MarginSmall';

--- a/src/components/ui/margins/marginSmall.tsx
+++ b/src/components/ui/margins/marginSmall.tsx
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 
 export const MarginSmall = styled.div`
+  max-width: var(--margin-small);
+  min-width: var(--margin-small);
   margin: var(--margin-small);
+  display: flex;
 `;
 
 MarginSmall.displayName = 'MarginSmall';

--- a/src/pages/blogg.tsx
+++ b/src/pages/blogg.tsx
@@ -4,10 +4,10 @@ import { ResponsiveContainer } from '../components/ui/container/responsiveContai
 import { TextCenter } from '../components/ui/content/textCenter';
 import { UnstyledInternalLink } from '../components/ui/content/unstyledLink';
 import { MarginLarge } from '../components/ui/margins/marginLarge';
-import { MarginMedium } from '../components/ui/margins/marginMedium';
 import { useContent } from '../context/ContentContext';
 import { HeadingMuted } from '../components/ui/content/headingMuted';
 import { Column } from '../components/ui/container/column';
+import { MarginSmall } from '../components/ui/margins/marginSmall';
 
 const blogIndex = () => {
   const { blogPosts } = useContent();
@@ -28,7 +28,7 @@ const blogIndex = () => {
             <UnstyledInternalLink key={blogPost.title} href={blogPost.url}>
               <div>
                 <PostListItem {...blogPost} />
-                <MarginMedium />
+                <MarginSmall />
               </div>
             </UnstyledInternalLink>
           ))}

--- a/src/theme/parts/margins.ts
+++ b/src/theme/parts/margins.ts
@@ -1,7 +1,7 @@
-import { Margins } from '../../types/theme/Margins';
+import { Spacing } from '../../types/theme/Spacing';
 
-export const margins: Margins = {
-  small: '5px',
-  medium: '10px',
-  large: '20px',
+export const margins: { [key in Spacing]: string } = {
+  [Spacing.Small]: '5px',
+  [Spacing.Medium]: '10px',
+  [Spacing.Large]: '20px',
 };

--- a/src/types/theme/Margins.ts
+++ b/src/types/theme/Margins.ts
@@ -1,5 +1,0 @@
-export interface Margins {
-  small: string;
-  medium: string;
-  large: string;
-}

--- a/src/types/theme/Spacing.ts
+++ b/src/types/theme/Spacing.ts
@@ -1,0 +1,5 @@
+export enum Spacing {
+  Small = 'small',
+  Medium = 'medium',
+  Large = 'large',
+}


### PR DESCRIPTION
## What this pull request does

This pull request refactors margin components. Large, medium and small components now all use the same Margin component but set different sizes.

Bonus bugfix: The margin components did not properly enforce their space in all design contexts. In some cases a MarginMedium did not take all it's intended space for example.

### Types of changes

- [x] 🐛 Bug fixes
- [ ] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
