### PR TITLE
Swap icon pack to one that is more in line with sites font

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@mdx-js/react": "^1.6.6",
-    "@styled-icons/feather": "^10.5.0",
+    "@styled-icons/evaicons-outline": "^10.18.0",
     "color": "^3.1.2",
     "date-fns": "^2.14.0",
     "framer-motion": "^2.9.4",

--- a/src/components/ui/icons/iconDarkMode.tsx
+++ b/src/components/ui/icons/iconDarkMode.tsx
@@ -1,7 +1,7 @@
-import { Moon } from '@styled-icons/feather';
 import { IconBase, IconComponentProps, renderIcon } from './iconBase/iconBase';
+import { Icons } from './icons';
 
-const Icon = IconBase(Moon);
+const Icon = IconBase(Icons.Moon);
 
 export const IconDarkMode: React.FC<IconComponentProps> = (props) => renderIcon(Icon, props);
 

--- a/src/components/ui/icons/iconGitHub.tsx
+++ b/src/components/ui/icons/iconGitHub.tsx
@@ -1,7 +1,7 @@
-import { Github } from '@styled-icons/feather';
 import { IconBase, IconComponentProps, renderIcon } from './iconBase/iconBase';
+import { Icons } from './icons';
 
-const Icon = IconBase(Github);
+const Icon = IconBase(Icons.Github);
 
 export const IconGitHub: React.FC<IconComponentProps> = (props) => renderIcon(Icon, props);
 

--- a/src/components/ui/icons/iconLightMode.tsx
+++ b/src/components/ui/icons/iconLightMode.tsx
@@ -1,7 +1,7 @@
-import { Sun } from '@styled-icons/feather';
 import { IconBase, IconComponentProps, renderIcon } from './iconBase/iconBase';
+import { Icons } from './icons';
 
-const Icon = IconBase(Sun);
+const Icon = IconBase(Icons.Sun);
 
 export const IconLightMode: React.FC<IconComponentProps> = (props) => renderIcon(Icon, props);
 IconLightMode.displayName = 'IconLightMode';

--- a/src/components/ui/icons/iconMail.tsx
+++ b/src/components/ui/icons/iconMail.tsx
@@ -1,7 +1,7 @@
-import { Mail } from '@styled-icons/feather';
 import { IconBase, IconComponentProps, renderIcon } from './iconBase/iconBase';
+import { Icons } from './icons';
 
-const Icon = IconBase(Mail);
+const Icon = IconBase(Icons.Email);
 
 export const IconMail: React.FC<IconComponentProps> = (props) => renderIcon(Icon, props);
 

--- a/src/components/ui/icons/icons.tsx
+++ b/src/components/ui/icons/icons.tsx
@@ -1,0 +1,8 @@
+import { EmailOutline, GithubOutline, MoonOutline, SunOutline } from '@styled-icons/evaicons-outline';
+
+export const Icons = {
+  Github: GithubOutline,
+  Moon: MoonOutline,
+  Sun: SunOutline,
+  Email: EmailOutline
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1260,10 +1260,10 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@styled-icons/feather@^10.5.0":
+"@styled-icons/evaicons-outline@^10.18.0":
   version "10.18.0"
-  resolved "https://registry.yarnpkg.com/@styled-icons/feather/-/feather-10.18.0.tgz#eaec56120c4113930edd2551aaf8d8b9da565219"
-  integrity sha512-W8ESG+KLaiCekydTV6LaP3FW5enwvGMSM2T/wvS8HPmnR6tFb4hn8VQrtXG8Bwdc5RmTJ+2eyN6N3KySMfMC4Q==
+  resolved "https://registry.yarnpkg.com/@styled-icons/evaicons-outline/-/evaicons-outline-10.18.0.tgz#3a7a00a97244fcefcad70e94d81eb151d5fdf9b9"
+  integrity sha512-6D352LtvtzfHlhxgUeair6NPfyJ0y6V+1r710w1qoEVO/mnc9F+ED6MaOCDv8GeDOM3eCPd8y2Fs6EA8zKuv/A==
   dependencies:
     "@babel/runtime" "^7.10.5"
     "@styled-icons/styled-icon" "^10.6.0"


### PR DESCRIPTION
## What this pull request does

This pull request changes the styled-icons icon pack from feather to evaicons-outline. This pack is more in line with the site font. Feather was to thin.

Bonus: Move icons into a sharable icon object. This means that when changes icons the next time (or adding new ones) only the file with icons object will have to import new icons. The icon reference in each icon component will stay the same.

### Types of changes

- [ ] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
