### PR TITLE
Revert to use regular lazy loading images in articles

### DIFF
--- a/src/components/mdx/customImageComponent.tsx
+++ b/src/components/mdx/customImageComponent.tsx
@@ -1,5 +1,3 @@
-import Image from 'next/image';
-
 export const customImageComponent = (props: any) => {
-  return <Image unsized {...props} />;
+  return <img loading="lazy" {...props} />;
 };


### PR DESCRIPTION
## What this pull request does

This pull request reverts usage of the very new Image component provided by Next.js for article images to just use a regular image tag with `loading="lazy"`.

This is due to some kinks with the new Image component that I have not worked out yet - and regular image html tag serves my purpose for now. No need to introduce complexity when not warranted

### Types of changes

- [ ] 🐛 Bug fixes
- [ ] 💅 New features
- [x] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
