### PR TITLE
Tokenize code blocks

### DIFF
--- a/src/components/ui/SyntaxHighlighter.tsx
+++ b/src/components/ui/SyntaxHighlighter.tsx
@@ -108,7 +108,7 @@ export const SyntaxHighlighter = styled('div', {
    */
   '.code-highlight': {
     float: 'left' /* 1 */,
-    minWidth: '100%' /* 2 */,
+    minWidth: '97%' /* 2 */,
   },
 
   '.highlight-line': {

--- a/src/components/ui/SyntaxHighlighter.tsx
+++ b/src/components/ui/SyntaxHighlighter.tsx
@@ -1,8 +1,18 @@
 import { styled } from 'theme';
 
 export const SyntaxHighlighter = styled('div', {
+  $$tokenBackground: '#2e3440',
+  $$tokenBackgroundHighlight: '#3b414ccc',
+  $$tokenCommentColor: '#636f88',
+  $$tokenRegexColor: '#ebcb8b',
+  $$tokenPropertyColor: '#81a1c1',
+  $$tokenNumberColor: '#b48ead',
+  $$tokenSelectorColor: '#a3be8c',
+  $$tokenFunctionColor: '#88c0d0',
+  $$tokenBaseColor: '#f8f8f2',
+
   'code[class*="language-"], pre[class*="language-"]': {
-    color: '#f8f8f2',
+    color: '$$tokenBaseColor',
     background: 'none',
     display: 'block',
     fontFamily: '$mono',
@@ -24,7 +34,7 @@ export const SyntaxHighlighter = styled('div', {
     borderRadius: '$small',
   },
   ':not(pre) > code[class*="language-"], pre[class*="language-"]': {
-    background: '#2e3440',
+    background: '$$tokenBackground',
   },
   ':not(pre) > code[class*="language-"]': {
     padding: '01.em',
@@ -32,38 +42,38 @@ export const SyntaxHighlighter = styled('div', {
     whiteSpace: 'normal',
   },
   '.token.comment, .token.prolog, .token.doctype, .token.cdata': {
-    color: '#636f88',
+    color: '$$tokenCommentColor',
   },
   '.token.punctuation': {
-    color: '#81a1c1',
+    color: '$$tokenPropertyColor',
   },
   '.namespace': {
     opacity: 0.7,
   },
   '.token.property, .token.tag, .token.constant, .token.symbol, .token.deleted': {
-    color: '#81a1c1',
+    color: '$$tokenPropertyColor',
   },
   '.token.number': {
-    color: '#b48ead',
+    color: '$$tokenNumberColor',
   },
   '.token.boolean': {
-    color: '#81a1c1',
+    color: '$$tokenPropertyColor',
   },
   '.token.selector, .token.attr-name, .token.string, .token.char, .token.builtin, .token.inserted': {
-    color: '#a3be8c',
+    color: '$$tokenSelectorColor',
   },
   '.token.operator, .token.entity, .token.url, .language-css .token.string, .style .token.string, .token.variable': {
-    color: '#81a1c1',
+    color: '$$tokenPropertyColor',
   },
   '.token.atrule, .token.attr-value, .token.function, .token.class-name': {
-    color: '#88c0d0',
+    color: '$$tokenFunctionColor',
   },
   '.token.keyword': {
-    color: '#81a1c1',
+    color: '$$tokenPropertyColor',
   },
 
   '.token.regex, .token.important': {
-    color: '#ebcb8b',
+    color: '$$tokenRegexColor',
   },
 
   '.token.important, .token.bold': {
@@ -82,10 +92,10 @@ export const SyntaxHighlighter = styled('div', {
     fontFamily: '$mono',
     marginBottom: '-0.8rem',
     padding: '0.7em 1em 0.5em 1em',
-    background: '#2e3440',
+    background: '$$tokenBackground',
     textAligh: 'left',
     fontWeight: 400,
-    color: '#636f88',
+    color: '$$tokenCommentColor',
     borderTopRightRadius: '4px',
     borderTopLeftRadius: '4px',
     fontSize: '$small',
@@ -102,12 +112,12 @@ export const SyntaxHighlighter = styled('div', {
   },
 
   '.highlight-line': {
-    marginLeft: '-1.55em',
-    paddingLeft: '1em',
+    background: '$$tokenBackgroundHighlight',
     display: 'block',
-    borderLeft: '6px solid #88c0d0',
-    marginRight: '-1.5em',
-    background: '#3b414ccc',
+    marginLeft: '-20px',
+    paddingLeft: '20px',
+    marginRight: '-20px',
+    paddingRight: '20px',
   },
 
   '.line-number::before': {
@@ -116,7 +126,7 @@ export const SyntaxHighlighter = styled('div', {
     textAlign: 'right',
     marginRight: '16px',
     marginLeft: '-8px',
-    color: 'rgb(99, 111, 136)',
+    color: '$$tokenCommentColor',
     content: 'attr(line)',
   },
 });

--- a/src/components/ui/SyntaxHighlighter.tsx
+++ b/src/components/ui/SyntaxHighlighter.tsx
@@ -1,14 +1,22 @@
+import color from 'color';
 import { styled } from 'theme';
 
+const background = '#2E3440';
+const highlight = color(background).lighten(0.3).hex();
+
 export const SyntaxHighlighter = styled('div', {
-  $$tokenBackground: '#2e3440',
-  $$tokenBackgroundHighlight: '#3b414ccc',
+  $$tokenBackground: background,
+  $$tokenBackgroundHighlight: highlight,
   $$tokenCommentColor: '#636f88',
   $$tokenRegexColor: '#ebcb8b',
-  $$tokenPropertyColor: '#81a1c1',
-  $$tokenNumberColor: '#b48ead',
-  $$tokenSelectorColor: '#a3be8c',
-  $$tokenFunctionColor: '#88c0d0',
+  $$tokenPropertyColor: '#81A1C1',
+  $$tokenNumberColor: '#B48EAD',
+  $$tokenSelectorColor: 'rgb(199, 146, 234)',
+  $$tokenBooleanColor: '$$tokenPropertyColor',
+  $$tokenPunctuationColor: '#81A1C1',
+  $$tokenFunctionColor: '#88C0D0',
+  $$tokenStringColor: '#A3BE8C',
+  $$tokenOperator: '#81A1C1',
   $$tokenBaseColor: '#f8f8f2',
 
   'code[class*="language-"], pre[class*="language-"]': {
@@ -45,7 +53,7 @@ export const SyntaxHighlighter = styled('div', {
     color: '$$tokenCommentColor',
   },
   '.token.punctuation': {
-    color: '$$tokenPropertyColor',
+    color: '$$tokenPunctuationColor',
   },
   '.namespace': {
     opacity: 0.7,
@@ -57,13 +65,13 @@ export const SyntaxHighlighter = styled('div', {
     color: '$$tokenNumberColor',
   },
   '.token.boolean': {
-    color: '$$tokenPropertyColor',
+    color: '$$tokenBooleanColor',
   },
   '.token.selector, .token.attr-name, .token.string, .token.char, .token.builtin, .token.inserted': {
-    color: '$$tokenSelectorColor',
+    color: '$$tokenStringColor',
   },
   '.token.operator, .token.entity, .token.url, .language-css .token.string, .style .token.string, .token.variable': {
-    color: '$$tokenPropertyColor',
+    color: '$$tokenOperator',
   },
   '.token.atrule, .token.attr-value, .token.function, .token.class-name': {
     color: '$$tokenFunctionColor',
@@ -114,10 +122,10 @@ export const SyntaxHighlighter = styled('div', {
   '.highlight-line': {
     background: '$$tokenBackgroundHighlight',
     display: 'block',
-    marginLeft: '-20px',
-    paddingLeft: '20px',
-    marginRight: '-20px',
-    paddingRight: '20px',
+    marginLeft: '-30px',
+    paddingLeft: '30px',
+    marginRight: '-30px',
+    paddingRight: '30px',
   },
 
   '.line-number::before': {

--- a/src/layouts/blogPost.tsx
+++ b/src/layouts/blogPost.tsx
@@ -23,7 +23,9 @@ export const BlogPostLayout: React.FC<PostPageProps> = ({ post, prevPost, nextPo
       <ResponsiveContainer>
         <Column>
           <MarginLarge />
-          <h1>{post.title}</h1>
+          <Header as="h1" gradient>
+            {post.title}
+          </Header>
           <DateText>{post.dateFormatted}</DateText>
           {post.description && (
             <Header as="h2" muted>

--- a/src/theme/global.css.ts
+++ b/src/theme/global.css.ts
@@ -110,8 +110,14 @@ export const globalStyles = globalCss({
     color: '$textColor',
     background: '$backgroundColorHighlight',
     borderRadius: '$small',
-    fontWeight: 400,
-    padding: '4px',
+    fontWeight: 'bold',
+    padding: '6px',
+  },
+  'code:not([class^="language"])': {
+    '&:after, &:before': {
+      content: '`',
+      fontWeight: 'bold',
+    },
   },
 
   strong: {

--- a/src/theme/theme.config.ts
+++ b/src/theme/theme.config.ts
@@ -107,7 +107,7 @@ export const darkTheme = createTheme({
     backgroundColorSecondary: '#202438',
     backgroundColorHighlight: '#202438',
     backgroundColorNavBar: 'hsl(230deg 21% 11% / 75%)',
-    textColor: '#bec0c9',
+    textColor: '#cdcdcd',
     textMutedColor: '#87919e',
     headingColor: '#e4e4e4',
   },


### PR DESCRIPTION
## What this pull request does

This pull request tries to tokenize the colors in the prism theme.
Also try and distinguish regular code elements with backticks

**Bugfix:** Try and prevent overflowing scrollbars in code blocks when highlighting with less than 100% width:

### Types of changes

- [x] 🐛 Bug fixes
- [x] 💅 New features
- [ ] 🚧 Code refactoring
- [ ] 📜 Article
- [ ] 🧹 Chores
- [ ] 📝 Documentation
